### PR TITLE
BUG - When p is not provided

### DIFF
--- a/da_rnn/keras/model.py
+++ b/da_rnn/keras/model.py
@@ -424,7 +424,7 @@ class DARNN(Model):
         self.y_dim = y_dim
 
         self.encoder = Encoder(T, m)
-        self.decoder = Decoder(T, m, p, y_dim=y_dim)
+        self.decoder = Decoder(T, m, self.p, y_dim=y_dim)
 
     # Equation 1
     def call(self, inputs):


### PR DESCRIPTION
Fixes : `TypeError: '<' not supported between instances of 'NoneType' and 'int'`